### PR TITLE
Add full version of quickstart code

### DIFF
--- a/examples/_quick-start/README.md
+++ b/examples/_quick-start/README.md
@@ -1,0 +1,17 @@
+# Quick Start
+
+This is the full version of the code accompanying the Developer Quick Start.
+
+You can run it against a Vault dev server to write and read your first secret!
+
+To start up a Vault dev server, run:
+
+```
+docker run -p 8200:8200 -e 'VAULT_DEV_ROOT_TOKEN_ID=dev-only-token' vault
+```
+
+or without Docker,
+
+```
+vault server -dev -dev-root-token-id="dev-only-token"
+```

--- a/examples/_quick-start/dotnet/Example.cs
+++ b/examples/_quick-start/dotnet/Example.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using VaultSharp;
+using VaultSharp.V1.AuthMethods;
+using VaultSharp.V1.AuthMethods.Token;
+using VaultSharp.V1.Commons;
+
+// This is the full version of the code accompanying the Developer Quick Start.
+// WARNING: Using root tokens is insecure and should never be done in production!
+namespace DeveloperQuickstart
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            // Authentication
+            IAuthMethodInfo authMethod = new TokenAuthMethodInfo(vaultToken: "dev-only-token");
+
+            VaultClientSettings vaultClientSettings = new VaultClientSettings("http://127.0.0.1:8200", authMethod);
+            IVaultClient vaultClient = new VaultClient(vaultClientSettings);
+
+            // Writing a secret
+            var secretData = new Dictionary<string, object> { { "password", "Hashi123" } };
+            vaultClient.V1.Secrets.KeyValue.V2.WriteSecretAsync(
+                path: "/my-secret-password",
+                data: secretData,
+                mountPoint: "secret"
+            ).Wait();
+
+            Console.WriteLine("Secret written successfully.");
+
+            // Reading a secret
+            Secret<SecretData> secret = vaultClient.V1.Secrets.KeyValue.V2.ReadSecretAsync(
+                path: "/my-secret-password",
+                mountPoint: "secret"
+            ).Result;
+
+            var password = secret.Data.Data["password"];
+
+            if (password.ToString() != "Hashi123")
+            {
+                throw new System.Exception("Unexpected password");
+            }
+
+            Console.WriteLine("Access granted!");
+        }
+    }
+}

--- a/examples/_quick-start/dotnet/Example.cs
+++ b/examples/_quick-start/dotnet/Example.cs
@@ -5,7 +5,7 @@ using VaultSharp.V1.AuthMethods;
 using VaultSharp.V1.AuthMethods.Token;
 using VaultSharp.V1.Commons;
 
-// This is the full version of the code accompanying the Developer Quick Start.
+// This is the accompanying code for the Developer Quick Start.
 // WARNING: Using root tokens is insecure and should never be done in production!
 namespace DeveloperQuickstart
 {

--- a/examples/_quick-start/go/example.go
+++ b/examples/_quick-start/go/example.go
@@ -7,7 +7,7 @@ import (
 	vault "github.com/hashicorp/vault/api"
 )
 
-// This is the full version of the code accompanying the Developer Quick Start.
+// This is the accompanying code for the Developer Quick Start.
 // WARNING: Using root tokens is insecure and should never be done in production!
 func main() {
 	config := vault.DefaultConfig()

--- a/examples/_quick-start/go/example.go
+++ b/examples/_quick-start/go/example.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	vault "github.com/hashicorp/vault/api"
+)
+
+// This is the full version of the code accompanying the Developer Quick Start.
+// WARNING: Using root tokens is insecure and should never be done in production!
+func main() {
+	config := vault.DefaultConfig()
+
+	config.Address = "http://127.0.0.1:8200"
+
+	client, err := vault.NewClient(config)
+	if err != nil {
+		log.Fatalf("unable to initialize Vault client: %v", err)
+	}
+
+	// Authentication
+	client.SetToken("dev-only-token")
+
+	secretData := map[string]interface{}{
+		"data": map[string]interface{}{
+			"password": "Hashi123",
+		},
+	}
+
+	// Writing a secret
+	_, err = client.Logical().Write("secret/data/my-secret-password", secretData)
+	if err != nil {
+		log.Fatalf("unable to write secret: %v", err)
+	}
+
+	fmt.Println("Secret written successfully.")
+
+	// Reading a secret
+	secret, err := client.Logical().Read("secret/data/my-secret-password")
+	if err != nil {
+		log.Fatalf("unable to read secret: %v", err)
+	}
+
+	data, ok := secret.Data["data"].(map[string]interface{})
+	if !ok {
+		log.Fatalf("data type assertion failed: %T %#v", secret.Data["data"], secret.Data["data"])
+	}
+
+	key := "password"
+	value, ok := data[key].(string)
+	if !ok {
+		log.Fatalf("value type assertion failed: %T %#v", data[key], data[key])
+	}
+
+	if value != "Hashi123" {
+		log.Fatalf("unexpected password value %q retrieved from vault", value)
+	}
+
+	fmt.Println("Access granted!")
+}


### PR DESCRIPTION
# Description

This is the full version of the code for the developer quickstart tutorial just so we can link to it instead of having it all inline. Once we have an actual link to the quickstart I can add a link to that here too.

While there are some obvious "code clean-up" things I could do here, I'm going to save that for the hello-vault copy of the quickstart, because this is meant to reflect exactly what happens in the step-by-step instructions of the quickstart guide (where I was fine with being more repetitive in the name of clarity at each step).

## Type of change

- [x] New example (non-breaking change that adds a new code example)

# How Has This Been Tested?

Ran against fresh dev servers started with both `vault server -dev -dev-root-token-id="dev-only-token"` and `docker run -p 8200:8200 -e 'VAULT_DEV_ROOT_TOKEN_ID=dev-only-token' vault`
