### PR TITLE
Add Python quickstart example

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ retrieve secrets.
   - Uses official library
     [HashiCorp Vault](https://pkg.go.dev/github.com/hashicorp/vault/api)
   - Provided examples:
+    - [Quick Start](examples/_quick-start/go/example.go) with Token Auth
     - Auth Methods ([AppRole](examples/auth-methods/approle/go/example.go),
       [AWS](examples/auth-methods/aws/go/example.go),
       [Azure](examples/auth-methods/azure/go/example.go),
@@ -20,11 +21,16 @@ retrieve secrets.
   - Uses community-maintained library
     [VaultSharp](https://github.com/rajanadar/VaultSharp)
   - Provided examples:
+    - [Quick Start](examples/_quick-start/dotnet/Example.cs) with Token Auth
     - Auth Methods ([AppRole](examples/auth-methods/approle/dotnet/Example.cs),
       [AWS](examples/auth-methods/aws/dotnet/Example.cs),
       [Azure](examples/auth-methods/azure/dotnet/Example.cs),
       [GCP](examples/auth-methods/gcp/dotnet/Example.cs),
       [Kubernetes](examples/auth-methods/kubernetes/dotnet/Example.cs))
+- Python
+  - Uses community-maintained library [HVAC](https://hvac.readthedocs.io/en/stable/overview.html)
+  - Provided examples:
+    - [Quick Start](examples/_quick-start/python/example.py) with Token Auth
 
 ## How To Use
 

--- a/examples/_quick-start/python/example.py
+++ b/examples/_quick-start/python/example.py
@@ -1,0 +1,26 @@
+import hvac
+import sys
+
+# Authentication
+client = hvac.Client(
+    url='http://127.0.0.1:8200',
+    token='dev-only-token',
+)
+
+# Writing a secret
+create_response = client.secrets.kv.v2.create_or_update_secret(
+    path='my-secret-password',
+    secret=dict(password='Hashi123'),
+)
+
+print('Secret written successfully.')
+
+# Reading a secret
+read_response = client.secrets.kv.read_secret_version(path='my-secret-password')
+
+password = read_response['data']['data']['password']
+
+if password != 'Hashi123':
+    sys.exit('unexpected password')
+
+print('Access granted!')


### PR DESCRIPTION
# Description

Adds quickstart code for Python, to be used in the developer quickstart guide.

## Type of change

- [x] New example (non-breaking change that adds a new code example)

# How Has This Been Tested?

Ran against two Vault dev servers, one that had been started with `vault server -dev -dev-root-token-id="dev-only-token"` and one with `docker run -p 8200:8200 -e 'VAULT_DEV_ROOT_TOKEN_ID=dev-only-token' vault`
