### PR TITLE
Java Spring Boot quickstart example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ retrieve secrets.
   - Uses community-maintained library [HVAC](https://hvac.readthedocs.io/en/stable/overview.html)
   - Provided examples:
     - [Quick Start](examples/_quick-start/python/example.py) with Token Auth
+- Java (Spring)
+  - Uses community-maintained library [spring-vault](https://spring.io/projects/spring-vault)
+  - Provided examples:
+    - [Quick Start](examples/_quick-start/java/Example.java) with Token Auth
 
 ## How To Use
 

--- a/examples/_quick-start/java/Example.java
+++ b/examples/_quick-start/java/Example.java
@@ -1,0 +1,57 @@
+package com.hashicorp.quickstart;
+
+import java.util.Map;
+import java.util.HashMap;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.ConfigurableApplicationContext;
+
+import org.springframework.vault.authentication.TokenAuthentication;
+import org.springframework.vault.client.VaultEndpoint;
+import org.springframework.vault.support.Versioned;
+import org.springframework.vault.core.VaultTemplate;
+
+@SpringBootApplication
+public class Example implements CommandLineRunner {
+    public static void main(String[] args) {
+        ConfigurableApplicationContext context = SpringApplication.run(Example.class, args);
+        context.close();
+    }
+
+    @Override
+    public void run(String... strings) throws Exception {
+        VaultEndpoint vaultEndpoint = new VaultEndpoint();
+
+        vaultEndpoint.setHost("127.0.0.1");
+        vaultEndpoint.setPort(8200);
+        vaultEndpoint.setScheme("http");
+
+        // Authenticate
+        VaultTemplate vaultTemplate = new VaultTemplate(vaultEndpoint,
+                new TokenAuthentication("dev-only-token"));
+
+        // Write a secret
+        Map<String, String> data = new HashMap<>();
+        data.put("password", "Hashi123");
+
+        Versioned.Metadata createResponse = vaultTemplate
+                .opsForVersionedKeyValue("secret")
+                .put("my-secret-password", data);
+
+        System.out.println("Secret written successfully.");
+
+        // Read a secret
+        Versioned<Map<String, Object>> readResponse = vaultTemplate
+                .opsForVersionedKeyValue("secret")
+                .get("my-secret-password");
+
+        String password = readResponse.getData().get("password").toString();
+
+        if (!password.equals("Hashi123")) {
+            throw new Exception("Unexpected password");
+        }
+
+        System.out.println("Access granted!");
+    }
+}

--- a/examples/_quick-start/java/Example.java
+++ b/examples/_quick-start/java/Example.java
@@ -28,7 +28,8 @@ public class Example implements CommandLineRunner {
         vaultEndpoint.setScheme("http");
 
         // Authenticate
-        VaultTemplate vaultTemplate = new VaultTemplate(vaultEndpoint,
+        VaultTemplate vaultTemplate = new VaultTemplate(
+                vaultEndpoint,
                 new TokenAuthentication("dev-only-token"));
 
         // Write a secret
@@ -46,7 +47,10 @@ public class Example implements CommandLineRunner {
                 .opsForVersionedKeyValue("secret")
                 .get("my-secret-password");
 
-        String password = readResponse.getData().get("password").toString();
+        String password = "";
+        if (readResponse != null && readResponse.hasData()) {
+            password = (String) readResponse.getData().get("password");
+        }
 
         if (!password.equals("Hashi123")) {
             throw new Exception("Unexpected password");


### PR DESCRIPTION
# Description

Adds code that will soon accompany the Developer Quickstart guide.

Note that the goal here is to provide something that is easily chopped up into steps as part of the Developer Quickstart, so I've tried my best to avoid doing anything outside of the run function (no autowire, extra classes, etc.) I intend to put a slightly more idiomatic version into hello-vault-spring.

## Type of change

- [x] New example (non-breaking change that adds a new code example)

# How Has This Been Tested?

Set up a Vault dev server with `vault server -dev -dev-root-token-id="dev-only-token"` as well as `docker run -p 8200:8200 -e 'VAULT_DEV_ROOT_TOKEN_ID=dev-only-token' vault`, then ran the `main` function with VSCode Java extension and saw expected output.
