### PR TITLE
Use KV helpers instead of Logical

### DIFF
--- a/examples/_quick-start/go/example.go
+++ b/examples/_quick-start/go/example.go
@@ -20,23 +20,23 @@ func main() {
 		log.Fatalf("unable to initialize Vault client: %v", err)
 	}
 
-	// Authentication
+	// Authenticate
 	client.SetToken("dev-only-token")
 
 	secretData := map[string]interface{}{
 		"password": "Hashi123",
 	}
 
-	// Writing a secret
-	_, err = client.KVv2("secret").Put(context.TODO(), "my-secret-password", secretData)
+	// Write a secret
+	_, err = client.KVv2("secret").Put(context.Background(), "my-secret-password", secretData)
 	if err != nil {
 		log.Fatalf("unable to write secret: %v", err)
 	}
 
 	fmt.Println("Secret written successfully.")
 
-	// Reading a secret
-	secret, err := client.KVv2("secret").Get(context.TODO(), "my-secret-password")
+	// Read a secret from the default mount path for KV v2 in dev mode, "secret"
+	secret, err := client.KVv2("secret").Get(context.Background(), "my-secret-password")
 	if err != nil {
 		log.Fatalf("unable to read secret: %v", err)
 	}

--- a/examples/_quick-start/go/example.go
+++ b/examples/_quick-start/go/example.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -23,13 +24,11 @@ func main() {
 	client.SetToken("dev-only-token")
 
 	secretData := map[string]interface{}{
-		"data": map[string]interface{}{
-			"password": "Hashi123",
-		},
+		"password": "Hashi123",
 	}
 
 	// Writing a secret
-	_, err = client.Logical().Write("secret/data/my-secret-password", secretData)
+	_, err = client.KVv2("secret").Put(context.TODO(), "my-secret-password", secretData)
 	if err != nil {
 		log.Fatalf("unable to write secret: %v", err)
 	}
@@ -37,20 +36,14 @@ func main() {
 	fmt.Println("Secret written successfully.")
 
 	// Reading a secret
-	secret, err := client.Logical().Read("secret/data/my-secret-password")
+	secret, err := client.KVv2("secret").Get(context.TODO(), "my-secret-password")
 	if err != nil {
 		log.Fatalf("unable to read secret: %v", err)
 	}
 
-	data, ok := secret.Data["data"].(map[string]interface{})
+	value, ok := secret.Data["password"].(string)
 	if !ok {
-		log.Fatalf("data type assertion failed: %T %#v", secret.Data["data"], secret.Data["data"])
-	}
-
-	key := "password"
-	value, ok := data[key].(string)
-	if !ok {
-		log.Fatalf("value type assertion failed: %T %#v", data[key], data[key])
+		log.Fatalf("value type assertion failed: %T %#v", secret.Data["password"], secret.Data["password"])
 	}
 
 	if value != "Hashi123" {

--- a/examples/auth-methods/approle/go/example.go
+++ b/examples/auth-methods/approle/go/example.go
@@ -41,7 +41,7 @@ func getSecretWithAppRole() (string, error) {
 		return "", fmt.Errorf("unable to initialize AppRole auth method: %w", err)
 	}
 
-	authInfo, err := client.Auth().Login(context.TODO(), appRoleAuth)
+	authInfo, err := client.Auth().Login(context.Background(), appRoleAuth)
 	if err != nil {
 		return "", fmt.Errorf("unable to login to AppRole auth method: %w", err)
 	}
@@ -49,8 +49,8 @@ func getSecretWithAppRole() (string, error) {
 		return "", fmt.Errorf("no auth info was returned after login")
 	}
 
-	// get secret
-	secret, err := client.KVv2("secret").Get(context.TODO(), "creds")
+	// get secret from the default mount path for KV v2 in dev mode, "secret"
+	secret, err := client.KVv2("secret").Get(context.Background(), "creds")
 	if err != nil {
 		return "", fmt.Errorf("unable to read secret: %w", err)
 	}

--- a/examples/auth-methods/approle/go/example.go
+++ b/examples/auth-methods/approle/go/example.go
@@ -50,22 +50,16 @@ func getSecretWithAppRole() (string, error) {
 	}
 
 	// get secret
-	secret, err := client.Logical().Read("kv-v2/data/creds")
+	secret, err := client.KVv2("secret").Get(context.TODO(), "creds")
 	if err != nil {
 		return "", fmt.Errorf("unable to read secret: %w", err)
 	}
 
-	data, ok := secret.Data["data"].(map[string]interface{})
-	if !ok {
-		return "", fmt.Errorf("data type assertion failed: %T %#v", secret.Data["data"], secret.Data["data"])
-	}
-
 	// data map can contain more than one key-value pair,
 	// in this case we're just grabbing one of them
-	key := "password"
-	value, ok := data[key].(string)
+	value, ok := secret.Data["password"].(string)
 	if !ok {
-		return "", fmt.Errorf("value type assertion failed: %T %#v", data[key], data[key])
+		return "", fmt.Errorf("value type assertion failed: %T %#v", secret.Data["password"], secret.Data["password"])
 	}
 
 	return value, nil

--- a/examples/auth-methods/aws/go/example.go
+++ b/examples/auth-methods/aws/go/example.go
@@ -34,22 +34,16 @@ func getSecretWithAWSAuthIAM() (string, error) {
 	}
 
 	// get secret
-	secret, err := client.Logical().Read("kv-v2/data/creds")
+	secret, err := client.KVv2("secret").Get(context.TODO(), "creds")
 	if err != nil {
 		return "", fmt.Errorf("unable to read secret: %w", err)
 	}
 
-	data, ok := secret.Data["data"].(map[string]interface{})
-	if !ok {
-		return "", fmt.Errorf("data type assertion failed: %T %#v", secret.Data["data"], secret.Data["data"])
-	}
-
 	// data map can contain more than one key-value pair,
 	// in this case we're just grabbing one of them
-	key := "password"
-	value, ok := data[key].(string)
+	value, ok := secret.Data["password"].(string)
 	if !ok {
-		return "", fmt.Errorf("value type assertion failed: %T %#v", data[key], data[key])
+		return "", fmt.Errorf("value type assertion failed: %T %#v", secret.Data["password"], secret.Data["password"])
 	}
 
 	return value, nil

--- a/examples/auth-methods/aws/go/example.go
+++ b/examples/auth-methods/aws/go/example.go
@@ -25,7 +25,7 @@ func getSecretWithAWSAuthIAM() (string, error) {
 		return "", fmt.Errorf("unable to initialize AWS auth method: %w", err)
 	}
 
-	authInfo, err := client.Auth().Login(context.TODO(), awsAuth)
+	authInfo, err := client.Auth().Login(context.Background(), awsAuth)
 	if err != nil {
 		return "", fmt.Errorf("unable to login to AWS auth method: %w", err)
 	}
@@ -33,8 +33,8 @@ func getSecretWithAWSAuthIAM() (string, error) {
 		return "", fmt.Errorf("no auth info was returned after login")
 	}
 
-	// get secret
-	secret, err := client.KVv2("secret").Get(context.TODO(), "creds")
+	// get secret from the default mount path for KV v2 in dev mode, "secret"
+	secret, err := client.KVv2("secret").Get(context.Background(), "creds")
 	if err != nil {
 		return "", fmt.Errorf("unable to read secret: %w", err)
 	}

--- a/examples/auth-methods/azure/go/example.go
+++ b/examples/auth-methods/azure/go/example.go
@@ -25,7 +25,7 @@ func getSecretWithAzureAuth() (string, error) {
 		return "", fmt.Errorf("unable to initialize Azure auth method: %w", err)
 	}
 
-	authInfo, err := client.Auth().Login(context.TODO(), azureAuth)
+	authInfo, err := client.Auth().Login(context.Background(), azureAuth)
 	if err != nil {
 		return "", fmt.Errorf("unable to login to Azure auth method: %w", err)
 	}
@@ -33,8 +33,8 @@ func getSecretWithAzureAuth() (string, error) {
 		return "", fmt.Errorf("no auth info was returned after login")
 	}
 
-	// get secret
-	secret, err := client.KVv2("secret").Get(context.TODO(), "creds")
+	// get secret from the default mount path for KV v2 in dev mode, "secret"
+	secret, err := client.KVv2("secret").Get(context.Background(), "creds")
 	if err != nil {
 		return "", fmt.Errorf("unable to read secret: %w", err)
 	}

--- a/examples/auth-methods/azure/go/example.go
+++ b/examples/auth-methods/azure/go/example.go
@@ -34,22 +34,16 @@ func getSecretWithAzureAuth() (string, error) {
 	}
 
 	// get secret
-	secret, err := client.Logical().Read("kv-v2/data/creds")
+	secret, err := client.KVv2("secret").Get(context.TODO(), "creds")
 	if err != nil {
 		return "", fmt.Errorf("unable to read secret: %w", err)
 	}
 
-	data, ok := secret.Data["data"].(map[string]interface{})
-	if !ok {
-		return "", fmt.Errorf("data type assertion failed: %T %#v", secret.Data["data"], secret.Data["data"])
-	}
-
 	// data map can contain more than one key-value pair,
 	// in this case we're just grabbing one of them
-	key := "password"
-	value, ok := data[key].(string)
+	value, ok := secret.Data["password"].(string)
 	if !ok {
-		return "", fmt.Errorf("value type assertion failed: %T %#v", data[key], data[key])
+		return "", fmt.Errorf("value type assertion failed: %T %#v", secret.Data["password"], secret.Data["password"])
 	}
 
 	return value, nil

--- a/examples/auth-methods/gcp/go/example.go
+++ b/examples/auth-methods/gcp/go/example.go
@@ -41,7 +41,7 @@ func getSecretWithGCPAuthIAM() (string, error) {
 		return "", fmt.Errorf("unable to initialize GCP auth method: %w", err)
 	}
 
-	authInfo, err := client.Auth().Login(context.TODO(), gcpAuth)
+	authInfo, err := client.Auth().Login(context.Background(), gcpAuth)
 	if err != nil {
 		return "", fmt.Errorf("unable to login to GCP auth method: %w", err)
 	}
@@ -49,8 +49,8 @@ func getSecretWithGCPAuthIAM() (string, error) {
 		return "", fmt.Errorf("login response did not return client token")
 	}
 
-	// get secret
-	secret, err := client.KVv2("secret").Get(context.TODO(), "creds")
+	// get secret from the default mount path for KV v2 in dev mode, "secret"
+	secret, err := client.KVv2("secret").Get(context.Background(), "creds")
 	if err != nil {
 		return "", fmt.Errorf("unable to read secret: %w", err)
 	}

--- a/examples/auth-methods/gcp/go/example.go
+++ b/examples/auth-methods/gcp/go/example.go
@@ -50,22 +50,16 @@ func getSecretWithGCPAuthIAM() (string, error) {
 	}
 
 	// get secret
-	secret, err := client.Logical().Read("kv-v2/data/creds")
+	secret, err := client.KVv2("secret").Get(context.TODO(), "creds")
 	if err != nil {
 		return "", fmt.Errorf("unable to read secret: %w", err)
 	}
 
-	data, ok := secret.Data["data"].(map[string]interface{})
-	if !ok {
-		return "", fmt.Errorf("data type assertion failed: %T %#v", secret.Data["data"], secret.Data["data"])
-	}
-
 	// data map can contain more than one key-value pair,
 	// in this case we're just grabbing one of them
-	key := "password"
-	value, ok := data[key].(string)
+	value, ok := secret.Data["password"].(string)
 	if !ok {
-		return "", fmt.Errorf("value type assertion failed: %T %#v", data[key], data[key])
+		return "", fmt.Errorf("value type assertion failed: %T %#v", secret.Data["password"], secret.Data["password"])
 	}
 
 	return value, nil

--- a/examples/auth-methods/kubernetes/go/example.go
+++ b/examples/auth-methods/kubernetes/go/example.go
@@ -33,7 +33,7 @@ func getSecretWithKubernetesAuth() (string, error) {
 		return "", fmt.Errorf("unable to initialize Kubernetes auth method: %w", err)
 	}
 
-	authInfo, err := client.Auth().Login(context.TODO(), k8sAuth)
+	authInfo, err := client.Auth().Login(context.Background(), k8sAuth)
 	if err != nil {
 		return "", fmt.Errorf("unable to log in with Kubernetes auth: %w", err)
 	}
@@ -41,8 +41,8 @@ func getSecretWithKubernetesAuth() (string, error) {
 		return "", fmt.Errorf("no auth info was returned after login")
 	}
 
-	// get secret from Vault
-	secret, err := client.KVv2("secret").Get(context.TODO(), "creds")
+	// get secret from Vault, from the default mount path for KV v2 in dev mode, "secret"
+	secret, err := client.KVv2("secret").Get(context.Background(), "creds")
 	if err != nil {
 		return "", fmt.Errorf("unable to read secret: %w", err)
 	}

--- a/examples/auth-methods/kubernetes/go/example.go
+++ b/examples/auth-methods/kubernetes/go/example.go
@@ -42,22 +42,16 @@ func getSecretWithKubernetesAuth() (string, error) {
 	}
 
 	// get secret from Vault
-	secret, err := client.Logical().Read("kv-v2/data/creds")
+	secret, err := client.KVv2("secret").Get(context.TODO(), "creds")
 	if err != nil {
 		return "", fmt.Errorf("unable to read secret: %w", err)
 	}
 
-	data, ok := secret.Data["data"].(map[string]interface{})
-	if !ok {
-		return "", fmt.Errorf("data type assertion failed: %T %#v", secret.Data["data"], secret.Data["data"])
-	}
-
 	// data map can contain more than one key-value pair,
 	// in this case we're just grabbing one of them
-	key := "password"
-	value, ok := data[key].(string)
+	value, ok := secret.Data["password"].(string)
 	if !ok {
-		return "", fmt.Errorf("value type assertion failed: %T %#v", data[key], data[key])
+		return "", fmt.Errorf("value type assertion failed: %T %#v", secret.Data["password"], secret.Data["password"])
 	}
 
 	return value, nil

--- a/examples/token-renewal/go/example.go
+++ b/examples/token-renewal/go/example.go
@@ -88,7 +88,7 @@ func login(client *vault.Client) (*vault.Secret, error) {
 		return nil, fmt.Errorf("unable to initialize userpass auth method: %w", err)
 	}
 
-	authInfo, err := client.Auth().Login(context.TODO(), userpassAuth)
+	authInfo, err := client.Auth().Login(context.Background(), userpassAuth)
 	if err != nil {
 		return nil, fmt.Errorf("unable to login to userpass auth method: %w", err)
 	}


### PR DESCRIPTION
# Description

Previously the only way to interact with the KV v2 API programmatically in Go was to make basic read/write requests using the `Logical()` struct. With `api/v.1.7.1` we've now introduced the KV helpers, so now we want to update our code examples to use those so more people are aware of them.

In the future we'll want to probably add some examples for our many other new KV helpers, but this PR is just to update what we currently have in this repo (mostly just Get requests).

## Type of change

- [x] Other (api method update)

# How Has This Been Tested?

Tested by running locally.
