### PR TITLE
update hvac Python module example to avoid running into permission issues

### DIFF
--- a/examples/_quick-start/python/example.py
+++ b/examples/_quick-start/python/example.py
@@ -8,9 +8,10 @@ import sys
 client = hvac.Client(
     url='http://127.0.0.1:8200',
     token='dev-only-token',
+    namespace='admin',  # If namespace is configured, make sure to set here
 )
 
-# Writing a secret
+# Writing a secret in the default secret engine
 create_response = client.secrets.kv.v2.create_or_update_secret(
     path='my-secret-password',
     secret=dict(password='Hashi123'),


### PR DESCRIPTION
Decided to use Hashicorp Vault Secret manager and spent days trying to read secrets using the hvac python module. 

Faced permission issues even though I followed example code:

`  raise exceptions.VaultError.from_status(
hvac.exceptions.Forbidden: 1 error occurred:
	* permission denied`

I created  a dev vault cluster managed by Hashicorp. Not sure if the issue exists if Vault cluster was hosted else where.

After specifying namespace in the `Client` method, I was able to read the secret

# Description

Added  namespace in the `Client` method and added a short comment. Also added another minor comment


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

create a Hasicorp Vault managed cluster and attempt to use the example without mentioning namespace in the `Client` method and see if it fails. if it does, try to mention namespace and see if it passes

